### PR TITLE
Uses orElseGet for getAwsCredentials

### DIFF
--- a/src/main/java/uk/co/lucasweb/aws/v4/signer/Signer.java
+++ b/src/main/java/uk/co/lucasweb/aws/v4/signer/Signer.java
@@ -152,7 +152,7 @@ public class Signer {
 
         private AwsCredentials getAwsCredentials() {
             return Optional.ofNullable(awsCredentials)
-                    .orElse(new AwsCredentialsProviderChain().getCredentials());
+                    .orElseGet(() -> new AwsCredentialsProviderChain().getCredentials());
         }
 
         private CanonicalHeaders getCanonicalHeaders() {


### PR DESCRIPTION
I got exception when i requested with no environment variables. But maybe this is not desirable behavior because I had specified AwsCredentials. I replaced `orElse` to `orElseGet` where reading credential values so that avoid evaluating environment variable when credentials are explicitly specified.