### PR TITLE
Remove S3 & Glacier Service Name Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ String contentSha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b
 HttpRequest request = new HttpRequest("GET", new URI("<YOUR_ENDPOINT>"));
 String signature = Signer.builder()
         .awsCredentials(new AwsCredentials(ACCESS_KEY, SECRET_KEY))
+        .region("<YOUR_REGION>")
         .header("Host", "<YOUR_HOST>")
         .header("x-amz-date", "20120525T002453Z")
         .build(request, "mediaconvert", contentSha256)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ String signature = Signer.builder()
         .header("Host", "examplebucket.s3.amazonaws.com")
         .header("x-amz-date", "20130524T000000Z")
         .header("x-amz-content-sha256", contentSha256)
-        .buildS3(request, contentSha256)
+        .build(request, "s3", contentSha256)
         .getSignature();
 }
 ```
@@ -45,7 +45,22 @@ String signature = Signer.builder()
         .header("Host", "glacier.us-east-1.amazonaws.com")
         .header("x-amz-date", "20120525T002453Z")
         .header("x-amz-glacier-version", "2012-06-01")
-        .buildGlacier(request, contentSha256)
+        .build(request, "glacier", contentSha256)
+        .getSignature();
+}
+```
+
+### Mediaconvert
+
+```java
+public class Example {
+String contentSha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+HttpRequest request = new HttpRequest("GET", new URI("<YOUR_ENDPOINT>"));
+String signature = Signer.builder()
+        .awsCredentials(new AwsCredentials(ACCESS_KEY, SECRET_KEY))
+        .header("Host", "<YOUR_HOST>")
+        .header("x-amz-date", "20120525T002453Z")
+        .build(request, "mediaconvert", contentSha256)
         .getSignature();
 }
 ```

--- a/src/main/java/uk/co/lucasweb/aws/v4/signer/Signer.java
+++ b/src/main/java/uk/co/lucasweb/aws/v4/signer/Signer.java
@@ -103,6 +103,8 @@ public class Signer {
     public static class Builder {
 
         private static final String DEFAULT_REGION = "us-east-1";
+        private static final String S3 = "s3";
+        private static final String GLACIER = "glacier";
 
         private AwsCredentials awsCredentials;
         private String region = DEFAULT_REGION;
@@ -143,6 +145,16 @@ public class Signer {
             CanonicalRequest canonicalRequest = new CanonicalRequest(service, request, canonicalHeaders, contentSha256);
             CredentialScope scope = new CredentialScope(dateWithoutTimestamp, service, region);
             return new Signer(canonicalRequest, awsCredentials, date, scope);
+        }
+        
+        @Deprecated
+        public Signer buildS3(HttpRequest request, String contentSha256) {
+            return build(request, S3, contentSha256);
+        }
+        
+        @Deprecated
+        public Signer buildGlacier(HttpRequest request, String contentSha256) {
+            return build(request, GLACIER, contentSha256);
         }
 
         private AwsCredentials getAwsCredentials() {

--- a/src/main/java/uk/co/lucasweb/aws/v4/signer/Signer.java
+++ b/src/main/java/uk/co/lucasweb/aws/v4/signer/Signer.java
@@ -103,8 +103,6 @@ public class Signer {
     public static class Builder {
 
         private static final String DEFAULT_REGION = "us-east-1";
-        private static final String S3 = "s3";
-        private static final String GLACIER = "glacier";
 
         private AwsCredentials awsCredentials;
         private String region = DEFAULT_REGION;
@@ -145,14 +143,6 @@ public class Signer {
             CanonicalRequest canonicalRequest = new CanonicalRequest(service, request, canonicalHeaders, contentSha256);
             CredentialScope scope = new CredentialScope(dateWithoutTimestamp, service, region);
             return new Signer(canonicalRequest, awsCredentials, date, scope);
-        }
-
-        public Signer buildS3(HttpRequest request, String contentSha256) {
-            return build(request, S3, contentSha256);
-        }
-
-        public Signer buildGlacier(HttpRequest request, String contentSha256) {
-            return build(request, GLACIER, contentSha256);
         }
 
         private AwsCredentials getAwsCredentials() {

--- a/src/test/java/uk/co/lucasweb/aws/v4/signer/SignerTest.java
+++ b/src/test/java/uk/co/lucasweb/aws/v4/signer/SignerTest.java
@@ -38,7 +38,7 @@ public class SignerTest {
                 .header("Host", "glacier.us-east-1.amazonaws.com")
                 .header("x-amz-date", "20120525T002453Z")
                 .header("x-amz-glacier-version", "2012-06-01")
-                .buildGlacier(request, hash)
+                .build(request, "glacier", hash)
                 .getSignature();
 
         String expectedSignature = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20120525/us-east-1/glacier/aws4_request, " +
@@ -57,7 +57,7 @@ public class SignerTest {
                 .header("Host", "examplebucket.s3.amazonaws.com")
                 .header("x-amz-date", "20130524T000000Z")
                 .header("x-amz-content-sha256", hash)
-                .buildS3(request, hash)
+                .build(request, "s3", hash)
                 .getSignature();
 
         String expectedSignature = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request, " +
@@ -88,7 +88,7 @@ public class SignerTest {
                 .header("x-amz-glacier-version", "2012-06-01")
                 .header("x-amz-sha256-tree-hash", treeHash)
                 .header("X-Amz-Target", "Glacier.UploadMultipartPart")
-                .buildGlacier(request, contentHash)
+                .build(request, "glacier", contentHash)
                 .getSignature();
 
         String expectedSignature = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20150424/us-east-1/glacier/aws4_request, " +


### PR DESCRIPTION
aws-v4-signer can be used for not only S3, Glacier but also other AWS services. So I removed some logics which are too dependent on S3 & Glacier service names and updated some examples & test cases. 