### PR TITLE
Adds slf4j logging to key places

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
+        <!-- compile dependency versions -->
+        <slf4j.version>1.7.25</slf4j.version>
+        
         <!-- test dependency versions -->
         <assertj-core.version>3.2.0</assertj-core.version>
         <junit.version>4.12</junit.version>
@@ -56,6 +59,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/src/main/java/uk/co/lucasweb/aws/v4/signer/CanonicalRequest.java
+++ b/src/main/java/uk/co/lucasweb/aws/v4/signer/CanonicalRequest.java
@@ -12,12 +12,13 @@
  */
 package uk.co.lucasweb.aws.v4.signer;
 
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.net.URISyntaxException;
-
 import java.util.ArrayList;
 import java.util.List;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.co.lucasweb.aws.v4.signer.encoding.URLEncoding;
 
 /**
@@ -25,6 +26,7 @@ import uk.co.lucasweb.aws.v4.signer.encoding.URLEncoding;
  */
 class CanonicalRequest {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final String S3_SERVICE = "s3";
     private static final char QUERY_PARAMETER_SEPARATOR = '&';
     private static final char QUERY_PARAMETER_VALUE_SEPARATOR = '=';
@@ -42,12 +44,14 @@ class CanonicalRequest {
     }
 
     String get() {
-        return httpRequest.getMethod() +
+        String canonicalRequest = httpRequest.getMethod() +
                 "\n" + normalizePath(httpRequest.getPath()) +
                 "\n" + normalizeQuery(httpRequest.getQuery()) +
                 "\n" + headers.get() +
                 "\n" + headers.getNames() +
                 "\n" + contentSha256;
+        LOGGER.debug("CanonicalRequest string = \n'{}'", canonicalRequest);
+        return canonicalRequest;
     }
 
     CanonicalHeaders getHeaders() {

--- a/src/main/java/uk/co/lucasweb/aws/v4/signer/CredentialScope.java
+++ b/src/main/java/uk/co/lucasweb/aws/v4/signer/CredentialScope.java
@@ -12,10 +12,15 @@
  */
 package uk.co.lucasweb.aws.v4.signer;
 
+import java.lang.invoke.MethodHandles;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * @author Yoann Rodiere
  */
 class CredentialScope {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     static final String TERMINATION_STRING = "aws4_request";
 
     private final String dateWithoutTimestamp;
@@ -42,7 +47,9 @@ class CredentialScope {
     }
 
     String get() {
-        return dateWithoutTimestamp + "/" + region + "/" + service + "/" + TERMINATION_STRING;
+        String credentialScope = dateWithoutTimestamp + "/" + region + "/" + service + "/" + TERMINATION_STRING;
+        LOGGER.debug("CredentialScope = '{}'", credentialScope);
+        return credentialScope;
     }
 
 }

--- a/src/main/java/uk/co/lucasweb/aws/v4/signer/hash/Sha256.java
+++ b/src/main/java/uk/co/lucasweb/aws/v4/signer/hash/Sha256.java
@@ -12,11 +12,10 @@
  */
 package uk.co.lucasweb.aws.v4.signer.hash;
 
-import uk.co.lucasweb.aws.v4.signer.SigningException;
-import uk.co.lucasweb.aws.v4.signer.functional.Throwables;
-
 import java.nio.charset.Charset;
 import java.security.MessageDigest;
+import uk.co.lucasweb.aws.v4.signer.SigningException;
+import uk.co.lucasweb.aws.v4.signer.functional.Throwables;
 
 /**
  * @author Richard Lucas
@@ -24,8 +23,7 @@ import java.security.MessageDigest;
 public final class Sha256 {
 
     private static final String SHA_256 = "SHA-256";
-    private static final String ZERO = "0";
-    private static final char[] hexDigits = "0123456789abcdef".toCharArray();
+    private static final char[] HEX_DIGITS = "0123456789abcdef".toCharArray();
 
     private Sha256() {
         // hide default constructor
@@ -36,7 +34,7 @@ public final class Sha256 {
             MessageDigest md = MessageDigest.getInstance(SHA_256);
             byte[] bytes = value.getBytes(charset);
             md.update(bytes);
-            int b = md.getDigestLength();
+            int b = md.getDigestLength();   // Is this needed?  'b' isn't used, but is this a test-for-exception check?
             return bytesToHex(md.digest());
         }, SigningException::new);
     }
@@ -44,7 +42,7 @@ public final class Sha256 {
     private static String bytesToHex(byte[] bytes) {
         StringBuilder sb = new StringBuilder(2 * bytes.length);
         for (byte b : bytes) {
-            sb.append(hexDigits[(b >> 4) & 0xf]).append(hexDigits[b & 0xf]);
+            sb.append(HEX_DIGITS[(b >> 4) & 0xf]).append(HEX_DIGITS[b & 0xf]);
         }
         return sb.toString();
     }

--- a/src/test/java/uk/co/lucasweb/aws/v4/signer/Sha256Test.java
+++ b/src/test/java/uk/co/lucasweb/aws/v4/signer/Sha256Test.java
@@ -12,12 +12,10 @@
  */
 package uk.co.lucasweb.aws.v4.signer;
 
+import java.nio.charset.Charset;
+import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
 import uk.co.lucasweb.aws.v4.signer.hash.Sha256;
-
-import java.nio.charset.Charset;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Richard Lucas
@@ -38,5 +36,11 @@ public class Sha256Test {
     public void shouldGetSha256() throws Exception {
         assertThat(Sha256.get(TEST, Charset.forName("UTF-8")))
                 .isEqualTo("5f1da1a2d0feb614dd03d71e87928b8e449ac87614479332aced3a701f916743");
+    }
+
+    @Test
+    public void shouldHashEmptyString() throws Exception {
+        assertThat(Sha256.get("", Charset.forName("UTF-8")))
+            .isEqualTo("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
     }
 }


### PR DESCRIPTION
Hi @lucasweb78 

Thanks so much for building this library!  I just used it for a project I was working on and was having trouble figuring out why AWS was giving me 403s with a message "your canonical string _should_ be 'blah blah blah'"

This PR adds the slf4j-api dependency which allows users of this JAR to provide their own logging implementation without tying them to any one hard and fast framework.  It adds debug statements at a couple of key points in the signing algorithm that gives the user helpful hints about how their signature is being constructed and, therefore, which part of the signature is causing the mis-match with what AWS is expecting.
